### PR TITLE
Chore/update dependencies

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,7 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## UNRELEASED
+## [3.0.0] # 2019-01-19
+- Upgraded to `reactstrap` 7.1.0 and `react-select` 2.3.0
+- Fixed plaintext rendering issues with reactstrap 7+
 - onCreateOption as async function in `CreatableSelect`
 - manage isLoading state of `CreatableSelect` in onCreateOption
 - old webpack config removed

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint": "tslint -t stylish --project ."
   },
   "dependencies": {
-    "@types/react-select": "^2.0.10",
-    "@types/reactstrap": "^6.4.3"
+    "@types/react-select": "^2.0.11",
+    "@types/reactstrap": "^6.4.4"
   },
   "peerDependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.8",
@@ -27,44 +27,44 @@
     "react-datetime": "^2.16.2",
     "react-ocean-forms": "^2.0.0",
     "react-select": "^2.1.1",
-    "reactstrap": "^6.1.0"
+    "reactstrap": "^7.1.0"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.10",
-    "@fortawesome/free-solid-svg-icons": "^5.6.1",
-    "@fortawesome/react-fontawesome": "^0.1.3",
+    "@fortawesome/fontawesome-svg-core": "^1.2.12",
+    "@fortawesome/free-solid-svg-icons": "^5.6.3",
+    "@fortawesome/react-fontawesome": "^0.1.4",
     "@types/enzyme": "^3.1.15",
     "@types/enzyme-adapter-react-16": "^1.0.3",
-    "@types/jest": "^23.3.10",
-    "@types/react": "^16.7.17",
+    "@types/jest": "^23.3.13",
+    "@types/react": "^16.7.20",
     "coveralls": "^3.0.2",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",
     "jest": "^23.6.0",
     "moment": "^2.23.0",
-    "react": "^16.6.3",
+    "react": "^16.7.0",
     "react-datetime": "^2.16.3",
-    "react-dom": "^16.6.3",
-    "react-ocean-forms": "^2.1.5",
-    "react-select": "^2.1.2",
-    "reactstrap": "^6.4.0",
-    "rollup": "^0.68.0",
+    "react-dom": "^16.7.0",
+    "react-ocean-forms": "^2.1.6",
+    "react-select": "^2.3.0",
+    "reactstrap": "^7.1.0",
+    "rollup": "^1.1.0",
     "rollup-plugin-commonjs": "^9.2.0",
-    "rollup-plugin-filesize": "^5.0.1",
+    "rollup-plugin-filesize": "^6.0.0",
     "rollup-plugin-node-resolve": "^4.0.0",
-    "rollup-plugin-sass": "^0.9.3",
-    "rollup-plugin-typescript2": "^0.18.1",
+    "rollup-plugin-sass": "^1.1.0",
+    "rollup-plugin-typescript2": "^0.19.2",
     "ts-jest": "23.10.5",
-    "ts-loader": "^5.3.1",
-    "tslint": "^5.11.0",
-    "tslint-consistent-codestyle": "^1.14.1",
+    "ts-loader": "^5.3.3",
+    "tslint": "^5.12.1",
+    "tslint-consistent-codestyle": "^1.15.0",
     "tslint-eaa-contrib": "^0.1.5",
     "tslint-microsoft-contrib": "^6.0.0",
     "tslint-react": "^3.6.0",
-    "typescript": "^3.2.2"
+    "typescript": "^3.2.4"
   },
   "resolutions": {
-    "@types/react": "16.7.17",
+    "@types/react": "16.7.20",
     "@types/enzyme": "^3.1.15"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react": "^16.4.0",
     "react-datetime": "^2.16.2",
     "react-ocean-forms": "^2.0.0",
-    "react-select": "^2.1.1",
+    "react-select": "^2.3.0",
     "reactstrap": "^7.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ocean-forms-bootstrap",
-  "version": "2.1.7",
+  "version": "3.0.0",
   "description": "Forms components for react based on the context api.",
   "main": "build/index.js",
   "module": "build/index.es.js",

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -82,7 +82,7 @@ export class BaseDatePicker extends React.Component<IDatePickerProps> {
 
       return (
         <FieldLine {...this.props}>
-          <StrapInput {...field} value="" plaintext>{displayValue}</StrapInput>
+          <StrapInput {...field} value={displayValue} plaintext />
         </FieldLine>
       );
     }

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -48,10 +48,8 @@ ShallowWrapper {
         onChange={[MockFunction]}
         plaintext={true}
         type="text"
-        value=""
-      >
-        Invalid date
-      </Input>,
+        value="Invalid date"
+      />,
       "field": Object {
         "disabled": false,
         "id": "mock-field",
@@ -80,7 +78,6 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "children": "Invalid date",
         "disabled": false,
         "id": "mock-field",
         "name": "mock-field",
@@ -88,10 +85,10 @@ ShallowWrapper {
         "onChange": [MockFunction],
         "plaintext": true,
         "type": "text",
-        "value": "",
+        "value": "Invalid date",
       },
       "ref": null,
-      "rendered": "Invalid date",
+      "rendered": null,
       "type": [Function],
     },
     "type": [Function],
@@ -110,10 +107,8 @@ ShallowWrapper {
           onChange={[MockFunction]}
           plaintext={true}
           type="text"
-          value=""
-        >
-          Invalid date
-        </Input>,
+          value="Invalid date"
+        />,
         "field": Object {
           "disabled": false,
           "id": "mock-field",
@@ -142,7 +137,6 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "children": "Invalid date",
           "disabled": false,
           "id": "mock-field",
           "name": "mock-field",
@@ -150,10 +144,10 @@ ShallowWrapper {
           "onChange": [MockFunction],
           "plaintext": true,
           "type": "text",
-          "value": "",
+          "value": "Invalid date",
         },
         "ref": null,
-        "rendered": "Invalid date",
+        "rendered": null,
         "type": [Function],
       },
       "type": [Function],

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -47,9 +47,7 @@ export class BaseInput extends React.Component<IInputProps> {
 
     return (
       <FieldLine {...this.props}>
-        <StrapInput type={type} {...field} value={fieldValue} invalid={invalid} plaintext={meta.plaintext}>
-          {meta.plaintext ? field.value : undefined}
-        </StrapInput>
+        <StrapInput type={type} {...field} value={fieldValue} invalid={invalid} plaintext={meta.plaintext} />
       </FieldLine>
     );
   }

--- a/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -50,9 +50,7 @@ ShallowWrapper {
         plaintext={true}
         type="text"
         value=""
-      >
-        
-      </Input>,
+      />,
       "field": Object {
         "disabled": false,
         "id": "mock-field",
@@ -82,7 +80,6 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "children": "",
         "disabled": false,
         "id": "mock-field",
         "invalid": undefined,
@@ -94,7 +91,7 @@ ShallowWrapper {
         "value": "",
       },
       "ref": null,
-      "rendered": "",
+      "rendered": null,
       "type": [Function],
     },
     "type": [Function],
@@ -114,9 +111,7 @@ ShallowWrapper {
           plaintext={true}
           type="text"
           value=""
-        >
-          
-        </Input>,
+        />,
         "field": Object {
           "disabled": false,
           "id": "mock-field",
@@ -146,7 +141,6 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "children": "",
           "disabled": false,
           "id": "mock-field",
           "invalid": undefined,
@@ -158,7 +152,7 @@ ShallowWrapper {
           "value": "",
         },
         "ref": null,
-        "rendered": "",
+        "rendered": null,
         "type": [Function],
       },
       "type": [Function],
@@ -264,7 +258,6 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "children": undefined,
         "disabled": false,
         "id": "mock-field",
         "invalid": undefined,
@@ -326,7 +319,6 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "children": undefined,
           "disabled": false,
           "id": "mock-field",
           "invalid": undefined,

--- a/src/components/Select/SelectBase/SelectBase.tsx
+++ b/src/components/Select/SelectBase/SelectBase.tsx
@@ -178,9 +178,7 @@ export class SelectBase extends React.Component<ISelectBaseProps> {
 
     return (
       <FieldLine {...this.props}>
-        <StrapInput {...field} value={displayValue} plaintext>
-          {displayValue}
-        </StrapInput>
+        <StrapInput {...field} value={displayValue} plaintext />
       </FieldLine>
     );
   }

--- a/src/components/Select/SelectBase/__snapshots__/SelectBase.test.tsx.snap
+++ b/src/components/Select/SelectBase/__snapshots__/SelectBase.test.tsx.snap
@@ -64,9 +64,7 @@ ShallowWrapper {
         plaintext={true}
         type="text"
         value=""
-      >
-        
-      </Input>,
+      />,
       "field": Object {
         "disabled": false,
         "id": "mock-field",
@@ -108,7 +106,6 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "children": "",
         "disabled": false,
         "id": "mock-field",
         "name": "mock-field",
@@ -119,7 +116,7 @@ ShallowWrapper {
         "value": "",
       },
       "ref": null,
-      "rendered": "",
+      "rendered": null,
       "type": [Function],
     },
     "type": [Function],
@@ -139,9 +136,7 @@ ShallowWrapper {
           plaintext={true}
           type="text"
           value=""
-        >
-          
-        </Input>,
+        />,
         "field": Object {
           "disabled": false,
           "id": "mock-field",
@@ -183,7 +178,6 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "children": "",
           "disabled": false,
           "id": "mock-field",
           "name": "mock-field",
@@ -194,7 +188,7 @@ ShallowWrapper {
           "value": "",
         },
         "ref": null,
-        "rendered": "",
+        "rendered": null,
         "type": [Function],
       },
       "type": [Function],
@@ -293,9 +287,7 @@ ShallowWrapper {
         plaintext={true}
         type="text"
         value="One, Two"
-      >
-        One, Two
-      </Input>,
+      />,
       "field": Object {
         "disabled": false,
         "id": "mock-field",
@@ -346,7 +338,6 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "children": "One, Two",
         "disabled": false,
         "id": "mock-field",
         "name": "mock-field",
@@ -357,7 +348,7 @@ ShallowWrapper {
         "value": "One, Two",
       },
       "ref": null,
-      "rendered": "One, Two",
+      "rendered": null,
       "type": [Function],
     },
     "type": [Function],
@@ -377,9 +368,7 @@ ShallowWrapper {
           plaintext={true}
           type="text"
           value="One, Two"
-        >
-          One, Two
-        </Input>,
+        />,
         "field": Object {
           "disabled": false,
           "id": "mock-field",
@@ -430,7 +419,6 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "children": "One, Two",
           "disabled": false,
           "id": "mock-field",
           "name": "mock-field",
@@ -441,7 +429,7 @@ ShallowWrapper {
           "value": "One, Two",
         },
         "ref": null,
-        "rendered": "One, Two",
+        "rendered": null,
         "type": [Function],
       },
       "type": [Function],
@@ -534,9 +522,7 @@ ShallowWrapper {
         plaintext={true}
         type="text"
         value="Two"
-      >
-        Two
-      </Input>,
+      />,
       "field": Object {
         "disabled": false,
         "id": "mock-field",
@@ -581,7 +567,6 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "children": "Two",
         "disabled": false,
         "id": "mock-field",
         "name": "mock-field",
@@ -592,7 +577,7 @@ ShallowWrapper {
         "value": "Two",
       },
       "ref": null,
-      "rendered": "Two",
+      "rendered": null,
       "type": [Function],
     },
     "type": [Function],
@@ -612,9 +597,7 @@ ShallowWrapper {
           plaintext={true}
           type="text"
           value="Two"
-        >
-          Two
-        </Input>,
+        />,
         "field": Object {
           "disabled": false,
           "id": "mock-field",
@@ -659,7 +642,6 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "children": "Two",
           "disabled": false,
           "id": "mock-field",
           "name": "mock-field",
@@ -670,7 +652,7 @@ ShallowWrapper {
           "value": "Two",
         },
         "ref": null,
-        "rendered": "Two",
+        "rendered": null,
         "type": [Function],
       },
       "type": [Function],

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,13 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/types@^7.0.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.3.tgz#3a767004567060c2f40fca49a304712c525ee37d"
@@ -70,45 +77,48 @@
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
-"@fimbul/bifrost@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.15.0.tgz#f3a48dee3046681e926c1f970f0b1a67e29e088e"
+"@fimbul/bifrost@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.17.0.tgz#f0383ba7e40992e3193dc87e2ddfde2ad62a9cf4"
+  integrity sha512-gVTkJAOef5HtN6LPmrtt5fAUmBywwlgmObsU3FBhPoNeXPLaIl2zywXkJEtvvVLQnaFmtff3x+wIj5lHRCDE3Q==
   dependencies:
-    "@fimbul/ymir" "^0.15.0"
+    "@fimbul/ymir" "^0.17.0"
     get-caller-file "^2.0.0"
     tslib "^1.8.1"
-    tsutils "^3.1.0"
+    tsutils "^3.5.0"
 
-"@fimbul/ymir@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@fimbul/ymir/-/ymir-0.15.0.tgz#944c881b14fadf7b43d1ae00b445e42261bb407f"
+"@fimbul/ymir@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@fimbul/ymir/-/ymir-0.17.0.tgz#4f28389b9f804d1cd202e11983af1743488b7815"
+  integrity sha512-xMXM9KTXRLHLVS6dnX1JhHNEkmWHcAVCQ/4+DA1KKwC/AFnGHzu/7QfQttEPgw3xplT+ILf9e3i64jrFwB3JtA==
   dependencies:
     inversify "^5.0.0"
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@fortawesome/fontawesome-common-types@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.10.tgz#ae0e6858daf6f9ff1e2396f9fbea87b244628343"
-  integrity sha512-FbrzSgFDzoC6Dm8w7gCWxgdffFbYV7O/4THOtYDQEplZVOpYIA3vjgnxCXApY49YaIQ91mxIGROS3d7wS+fO3A==
+"@fortawesome/fontawesome-common-types@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.12.tgz#42baa71f97ca06faeb0b6718fa5ed20c5eefdf07"
+  integrity sha512-ISLNpEx6fhJTYYkvBeo/4DHeL5EIA+VybJoOOnH67m6uXt6V6VFizdEN4qchHagNIeZfzI0LnA22gk0wbVPv/g==
 
-"@fortawesome/fontawesome-svg-core@^1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.10.tgz#235f82b209f36c94792a79b9aea127dfa29651c9"
-  integrity sha512-x9rYQ4jPVWnXgsle/MzaV2qDwNfc1Gm5DB0T76WOp4RDZ/esjEE0OvKtMa2qFvG1NqYbelgN4gChA+ttAqPtaw==
+"@fortawesome/fontawesome-svg-core@^1.2.12":
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.12.tgz#9732617b1e484435f6946645d7f9ad248f12c437"
+  integrity sha512-cqTfa3vZ+Z9UYQnmLfCOwyLnf0Xcoxkmm/BSaI29Yikzu9zIeD4es7lBZMDqLOXYSEQC+rCr8caxFlGJcJVA+w==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.10"
+    "@fortawesome/fontawesome-common-types" "^0.2.12"
 
-"@fortawesome/free-solid-svg-icons@^5.6.1":
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.6.1.tgz#5f6888639c8564a7ba98f4f295807ca5bc250e2c"
-  integrity sha512-J5es6So1zoT234XkYVkuDtHKeeNe7gvTM9VHdEwG8wSKwSIbdMixoNAMBbL88haGUolj0YjEmZwov4NMTx3Srw==
+"@fortawesome/free-solid-svg-icons@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.6.3.tgz#1d7f6669ccd6a1ea673699e41f7e32c81401a260"
+  integrity sha512-ld8Gfp1KrncOpFRheThUDlD6/Ro9ZJGqfCEMXlO/x1Cg7ltLc5iYDG7yxDowLcmFY2BGSmxIIU3ZMW5FVTrfwQ==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.10"
+    "@fortawesome/fontawesome-common-types" "^0.2.12"
 
-"@fortawesome/react-fontawesome@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.3.tgz#266b4047892c3d10498af1075d89252f74015b11"
+"@fortawesome/react-fontawesome@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz#18d61d9b583ca289a61aa7dccc05bd164d6bc9ad"
+  integrity sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==
   dependencies:
     humps "^2.0.1"
     prop-types "^15.5.10"
@@ -135,9 +145,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/jest@^23.3.10":
-  version "23.3.10"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
+"@types/jest@^23.3.13":
+  version "23.3.13"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.13.tgz#c81484b6f4ca007bb09887ed15ecb3286d58f928"
+  integrity sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA==
 
 "@types/node@*":
   version "10.11.7"
@@ -154,10 +165,10 @@
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react-select@^2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-2.0.10.tgz#04bfec166e87f24d46c1048af44c1963ea6b82d4"
-  integrity sha512-KpgFYzrPvIEcQys3EBBub02plGgI2CunV4lMN+6+ELr+XGcXPpQ9jC54qTLbXHaHZYzXYlChrVUKdnsaYZx5Gg==
+"@types/react-select@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-2.0.11.tgz#9b2b1fdb12b67a5a617c5f572e15617636cc65af"
+  integrity sha512-kITn4R50eUJCi2YT3JFZS4z5M2SJJqqYiVUX1HyLSFWbHbF6J25ZPKCCXANQrsnQzSrac2XiNpR5oYBif6l93g==
   dependencies:
     "@types/react" "*"
     "@types/react-dom" "*"
@@ -169,18 +180,18 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.7.17", "@types/react@^16.7.17":
-  version "16.7.17"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.17.tgz#3242e796a1ffbba4f49eae5915a67f4c079504e9"
-  integrity sha512-YcXcaoXaxo7A76mBCGlKlN2aZu3REQfF0DTrhiyXVJLA7PDdxVCr+wiQOrkVNn44D/zLlIyDSn3U918Ve0AaEA==
+"@types/react@*", "@types/react@16.7.20", "@types/react@^16.7.20":
+  version "16.7.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
+  integrity sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/reactstrap@^6.4.3":
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/@types/reactstrap/-/reactstrap-6.4.3.tgz#b6e1a0944d876726c76c5cb74c48bef02e56b4f9"
-  integrity sha512-+L26oBxuQRfGCbnWiyzY/u7wZl0pZRMjBnOuQpA1XegD/g3/wc9lDL+14hnWUIaJ/vacEQDrDIEOByGLmtIohg==
+"@types/reactstrap@^6.4.4":
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/@types/reactstrap/-/reactstrap-6.4.4.tgz#a3a87b81ea295596d8c7a0106f54b0dd9cfce647"
+  integrity sha512-UlR5HIitjdbce/+INRwvqq6UZEjpB0hCnbTBalZbTCLGKqWQDZcCxsy5+R/IJFb+Hv6zmGsz6TlDwnikK9D7IQ==
   dependencies:
     "@types/react" "*"
     popper.js "^1.14.1"
@@ -211,6 +222,11 @@ acorn@^5.5.3:
 acorn@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
+
+acorn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.5.tgz#81730c0815f3f3b34d8efa95cb7430965f4d887a"
+  integrity sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==
 
 ajv@^5.3.0:
   version "5.5.2"
@@ -1520,10 +1536,10 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
-  integrity sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==
+fs-extra@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -3455,14 +3471,15 @@ react-datetime@^2.16.3:
     prop-types "^15.5.7"
     react-onclickoutside "^6.5.0"
 
-react-dom@^16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
+react-dom@^16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
+  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.12.0"
 
 react-input-autosize@^2.2.1:
   version "2.2.1"
@@ -3482,10 +3499,10 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-ocean-forms@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/react-ocean-forms/-/react-ocean-forms-2.1.5.tgz#1c3d55e49112bb6f53ca6a444c961475fd04dd4a"
-  integrity sha512-iuZAH6lmj2fKIYZYkZmvwv6UTwfWZBnO5HzT46qzCEEmmZYdX7ardxA2vhv8QkdXHzyDU7lJO8uMLsZBt9p81Q==
+react-ocean-forms@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/react-ocean-forms/-/react-ocean-forms-2.1.6.tgz#b1945292dbe0cf9f257dd6a966ad3eac51ac341b"
+  integrity sha512-L1XhKgm48XzbhnAcWwbPYdnSwKs/Dxst0ga/vC1iSLaCHUsQFHYJZMJUGfyNW5N5Jw5AUeLI8dkag+5/43X2mA==
 
 react-onclickoutside@^6.5.0:
   version "6.7.1"
@@ -3498,9 +3515,10 @@ react-popper@^0.10.4:
     popper.js "^1.14.1"
     prop-types "^15.6.1"
 
-react-select@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.1.2.tgz#7a3e4c2b9efcd8c44ae7cf6ebb8b060ef69c513c"
+react-select@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.3.0.tgz#990429622445eb2b4a6e985b8069fe7d498cae91"
+  integrity sha512-CD3jyZs5lwy/CHW3SdYU1d1FtmJxgvVPdKMwEE8dD6MyNANFtvW95P/V20StPsPppFY7oePv/i2Mun2C2+WgTA==
   dependencies:
     classnames "^2.2.5"
     emotion "^9.1.2"
@@ -3528,19 +3546,22 @@ react-transition-group@^2.2.1, react-transition-group@^2.3.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@^16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
+react@^16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
+  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.12.0"
 
-reactstrap@^6.4.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-6.5.0.tgz#ba655e32646e2621829f61faa033e607ec6624e5"
+reactstrap@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-7.1.0.tgz#fd7125901737a3001c8564c0f8b40e319eec23b2"
+  integrity sha512-wtc4RkgnGn1TsZ0AxOZ2OqT+b8YmCWZj/tErPujWLepxzlEEhveZGC+uDerdaHVSAzJUP2DTk605iper7hutQQ==
   dependencies:
+    "@babel/runtime" "^7.2.0"
     classnames "^2.2.3"
     lodash.isfunction "^3.0.9"
     lodash.isobject "^3.0.2"
@@ -3599,6 +3620,11 @@ reflect-metadata@^0.1.12:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regex-cache@^0.4.2:
   version "0.4.4"
@@ -3722,10 +3748,10 @@ rollup-plugin-commonjs@^9.2.0:
     resolve "^1.8.1"
     rollup-pluginutils "^2.3.3"
 
-rollup-plugin-filesize@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-5.0.1.tgz#442a994465abf4f4f63ea20ac3267c3e0d05ee5d"
-  integrity sha512-zVUkEuJ543D86EaC5Ql2M6d6aAXwWbRwJ9NWSzTUS7F3vdd1cf+zlL+roQY8sW2hLIpbDMnGfev0dcy4bHQbjw==
+rollup-plugin-filesize@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-6.0.0.tgz#6188769eff2ee6f4508e0f6de5cf64409e2a269d"
+  integrity sha512-yU1nNkB2RP1PwLpBFIzH9oIwLL+Si6AEuy0/hAhFW+68hy6x/W/MxhhsUe7bDhG7Gnei7FOGC4Ag4W9+CninMQ==
   dependencies:
     boxen "^2.0.0"
     brotli-size "0.0.3"
@@ -3744,10 +3770,10 @@ rollup-plugin-node-resolve@^4.0.0:
     is-module "^1.0.0"
     resolve "^1.8.1"
 
-rollup-plugin-sass@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-sass/-/rollup-plugin-sass-0.9.3.tgz#0a686449a94beb911f94393634daba4ca8ff6ba2"
-  integrity sha512-RSPZWz4J6qROX1+HVETuG9Kw56lSpezoOcC8e67yMdVTk4ROxZSl6xiX97arhol15FQhfm32UD9BTFKgzpTgBw==
+rollup-plugin-sass@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-sass/-/rollup-plugin-sass-1.1.0.tgz#49bb6ba0d997c8357ce4ee98cdcb6905668cad92"
+  integrity sha512-4KLhANaZ9gmzB+VicZzL0Y5saA7eDo/PUugJ3/H88zUEXci/CV/QXbYPR7ewOkpR0ng9StLtz9d94ncvsZ5JpA==
   dependencies:
     babel-runtime "^6.23.0"
     fs-extra "^0.30.0"
@@ -3756,12 +3782,12 @@ rollup-plugin-sass@^0.9.3:
     rollup-pluginutils ">= 1.3.1"
     sass "1.7.2"
 
-rollup-plugin-typescript2@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.18.1.tgz#921865828080a254c088c6bc181ca654e5ef73c6"
-  integrity sha512-aR2m5NCCAUV/KpcKgCWX6Giy8rTko9z92b5t0NX9eZyjOftCvcdDFa1C9Ze/9yp590hnRymr5hG0O9SAXi1oUg==
+rollup-plugin-typescript2@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.19.2.tgz#87d9c799cd6e02efbedbba25af12753a1e92b6c2"
+  integrity sha512-DRG7SaYX0QzBIz6rII5nm1UkiceS95r8mJjujugybyIueNF3auvzGTHMK62O7As/0q5RHjXsOguWOUv+KJKLFA==
   dependencies:
-    fs-extra "7.0.0"
+    fs-extra "7.0.1"
     resolve "1.8.1"
     rollup-pluginutils "2.3.3"
     tslib "1.9.3"
@@ -3774,13 +3800,14 @@ rollup-pluginutils@2.3.3, "rollup-pluginutils@>= 1.3.1", rollup-pluginutils@^2.3
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
 
-rollup@^0.68.0:
-  version "0.68.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.68.0.tgz#e4fbde2e6278354962be530b498fc485298c0fc3"
-  integrity sha512-UbmntCf8QBlOqJnwsNWQCI0oonHOgs9y1OLoO8BHf2r8gCyRLp3JzLHXARJpsNDAS08Qm3LDjzyWma5sqnCxDQ==
+rollup@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.1.0.tgz#461a7534b55be48aa4a6e6810a1543a5769e75d1"
+  integrity sha512-NK03gkkOz0CchHBMGomcNqa6U3jLNzHuWK9SI0+1FV475JA6cQxVtjlDcQoKKDNIQ3IwYumIlgoKYDEWUyFBwQ==
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"
+    acorn "^6.0.5"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -3839,9 +3866,10 @@ schedule@^0.5.0:
   dependencies:
     object-assign "^4.1.1"
 
-scheduler@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
+scheduler@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
+  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -4287,9 +4315,10 @@ ts-jest@23.10.5:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-loader@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.3.1.tgz#70614c8ec4354a9c8b89c9f97b2becb7a98a3980"
+ts-loader@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.3.3.tgz#8b4af042e773132d86b3c99ef0acf3b4d325f473"
+  integrity sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==
   dependencies:
     chalk "^2.3.0"
     enhanced-resolve "^4.0.0"
@@ -4302,11 +4331,12 @@ tslib@1.9.3, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint-consistent-codestyle@^1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.14.1.tgz#8555f1b05ccbf093166a73347f41eb101731a522"
+tslint-consistent-codestyle@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.15.0.tgz#a3acf8d0a3ca0dc7d1285705102ba1fe4a17c4cb"
+  integrity sha512-6BNDBbZh2K0ibRXe70Mkl9gfVttxQ3t3hqV1BRDfpIcjrUoOgD946iH4SrXp+IggDgeMs3dJORjD5tqL5j4jXg==
   dependencies:
-    "@fimbul/bifrost" "^0.15.0"
+    "@fimbul/bifrost" "^0.17.0"
     tslib "^1.7.1"
     tsutils "^2.29.0"
 
@@ -4326,9 +4356,10 @@ tslint-react@^3.6.0:
   dependencies:
     tsutils "^2.13.1"
 
-tslint@^5.11.0:
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
+tslint@^5.12.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.1.tgz#8cec9d454cf8a1de9b0a26d7bdbad6de362e52c1"
+  integrity sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -4355,9 +4386,10 @@ tsutils@^2.13.1, tsutils@^2.27.2, tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-tsutils@^3.1.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.3.1.tgz#b7f34e23efbff41f729a712f0bfc628550c7119c"
+tsutils@^3.5.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.7.0.tgz#f97bdd2f109070bd1865467183e015b25734b477"
+  integrity sha512-n+e+3q7Jx2kfZw7tjfI9axEIWBY0sFMOlC+1K70X0SeXpO/UYSB+PN+E9tIJNqViB7oiXQdqD7dNchnvoneZew==
   dependencies:
     tslib "^1.8.1"
 
@@ -4377,10 +4409,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+typescript@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
### Summary
This PR turned out to be not as straight forward as I thought. I've updated all the dependencies, especially reactstrap to 7.1.0 - their breaking change introduced an render time crash if our plaintext mode was used. This is fixed with this release. Due to the reactstrap update I'll bump our version to 3.0.0.

### Checklist
Please ensure that you've fulfilled the following tasks:
* [x] My code follows the style guides of this project and `yarn lint` does not throw errors
* [x] My code is well tested and did not decrease the test coverage
* [x] All new and existing tests have passed
* [x] My submission passes the build
* [x] I've added changes to [CHANGELOG.MD](./CHANGELOG.MD)
* [x] I've updated the project documentation
