### PR TITLE
Hotfix for DatePicker onChange not triggering with empty string

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Fixed `DatePicker` not triggering an onChange while clearing its value
+
 ## [3.0.0] # 2019-01-19
 - Upgraded to `reactstrap` 7.1.0 and `react-select` 2.3.0
 - Fixed plaintext rendering issues with reactstrap 7+

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -94,7 +94,8 @@ describe('<DatePicker />', () => {
         throw new Error('Invalid test state');
       }
 
-      jest.spyOn(moment, 'isMoment').mockReturnValue(true);
+      const spiedIsMoment = jest.spyOn(moment, 'isMoment');
+      spiedIsMoment.mockReturnValue(true);
 
       const mockDate = {
         format: jest.fn().mockReturnValue('formatted-mock-date'),
@@ -104,6 +105,24 @@ describe('<DatePicker />', () => {
       expect(field.onChange).toHaveBeenCalledWith({
         target: {
           value: 'formatted-mock-date',
+        },
+      });
+
+      spiedIsMoment.mockRestore();
+    });
+
+    it('should call onChange correctly if the changed value is an empty string', () => {
+      const { wrapper, field } = setup();
+      const onChangeProp: Function | undefined = wrapper.find(Datetime).prop('onChange');
+
+      if (onChangeProp === undefined) {
+        throw new Error('Invalid test state');
+      }
+
+      onChangeProp('');
+      expect(field.onChange).toHaveBeenCalledWith({
+        target: {
+          value: '',
         },
       });
     });

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -22,14 +22,21 @@ export class BaseDatePicker extends React.Component<IDatePickerProps> {
   public static displayName: string = 'DatePicker';
 
   private handleChange = (value: moment.Moment | string): void => {
-    if (!(moment.isMoment(value))) { return; }
-
     const { field } = this.props;
-    field.onChange({
-      target: {
-        value: value.format(),
-      },
-    });
+
+    if (moment.isMoment(value)) {
+      field.onChange({
+        target: {
+          value: value.format(),
+        },
+      });
+    } else if (value === '') {
+      field.onChange({
+        target: {
+          value,
+        },
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
### Summary
Fixes #55 - DatePicker did not trigger an onChange form event if the changed value was an empty string / the DatePicker has been cleared.

### Checklist
Please ensure that you've fulfilled the following tasks:
* [x] My code follows the style guides of this project and `yarn lint` does not throw errors
* [x] My code is well tested and did not decrease the test coverage
* [x] All new and existing tests have passed
* [ ] My submission passes the build
* [x] I've added changes to [CHANGELOG.MD](./CHANGELOG.MD)
* [ ] I've updated the project documentation
